### PR TITLE
Ruby 2.3 Update OpenSSL 1.0.2q to 1.0.2u

### DIFF
--- a/share/ruby-build/2.3.0
+++ b/share/ruby-build/2.3.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl
 install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.1
+++ b/share/ruby-build/2.3.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl
 install_package "ruby-2.3.1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2#4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.2
+++ b/share/ruby-build/2.3.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl
 install_package "ruby-2.3.2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2#e6ce83d46819c4120c9295ff6b36b90393dd5f6bef3bb117a06d7399c11fc7c0" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.3
+++ b/share/ruby-build/2.3.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl
 install_package "ruby-2.3.3" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2#882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.4
+++ b/share/ruby-build/2.3.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl
 install_package "ruby-2.3.4" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2#cd9808bb53824d6edb58beaadd3906cb23b987438ce75ab7bb279b2229930e2f" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.5
+++ b/share/ruby-build/2.3.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl
 install_package "ruby-2.3.5" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2#f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.6
+++ b/share/ruby-build/2.3.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl
 install_package "ruby-2.3.6" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2#07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.7
+++ b/share/ruby-build/2.3.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl
 install_package "ruby-2.3.7" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2#18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.8
+++ b/share/ruby-build/2.3.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl
 install_package "ruby-2.3.8" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.bz2#4d1a3a88e8cf9aea624eb73843fbfc60a9a281582660f86d5e4e00870397407c" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Built in forks, the OpenSSL test passed.  I also added:
```
~/.rubies/ruby-${{ matrix.ruby-version }}/bin/ruby -ropenssl  -e 'puts "Build    " + OpenSSL::OPENSSL_VERSION, "Runtime  " + OpenSSL::OPENSSL_LIBRARY_VERSION, ""'
```
to the workflow yaml in ruby-install-builder in my fork.  Outputs the version info, both were:
```
OpenSSL 1.0.2u  20 Dec 2019
```
which is a lot better than
```
OpenSSL 1.0.2q  20 Nov 2018
```

JFYI, Windows builds have generally always used the most recent MSYS2 package.  But, since they have quite a few packages built with OpenSSL, they 'froze' at 1.0.2 and didn't update until 1.1.1 was released.  Hence, some experience with 1.0.2 LTS, and never saw a release break anything...