### PR TITLE
Support Ruby 1.9

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1077,7 +1077,7 @@ has_broken_mac_openssl() {
     local major="${ruby_version%%.*}"
     local minor_patch="${ruby_version#*.}"
     local minor="${minor_patch%%.*}"
-    local condition=$(($major == 2 && $minor <= 3))
+    local condition=$(($major == 2 && $minor <= 3) || ($major == 1 && $minor == 9))
     echo "Should build openssl for $ruby_version (major=$major, minor=$minor): $condition"
     return $((1 - $condition))
   fi

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1077,7 +1077,7 @@ has_broken_mac_openssl() {
     local major="${ruby_version%%.*}"
     local minor_patch="${ruby_version#*.}"
     local minor="${minor_patch%%.*}"
-    local condition=$(($major == 2 && $minor <= 3) || ($major == 1 && $minor == 9))
+    local condition=$((($major == 2 && $minor <= 3) || ($major == 1 && $minor == 9)))
     echo "Should build openssl for $ruby_version (major=$major, minor=$minor): $condition"
     return $((1 - $condition))
   fi


### PR DESCRIPTION
Support building older OpenSSL for Ruby 1.9 instead of just Ruby 2.0 to 2.3.

See: https://github.com/ruby/setup-ruby/issues/204